### PR TITLE
Update table_auto_delete.cronjob.php

### DIFF
--- a/lib/table_auto_delete.cronjob.php
+++ b/lib/table_auto_delete.cronjob.php
@@ -2,14 +2,51 @@
 
 class rex_cronjob_table_auto_delete extends rex_cronjob
 {
+    
     public function execute()
     {
         $sql = rex_sql::factory();
-        $sql->setQuery('DELETE FROM ' . $this->getParam('rex_table') . ' WHERE ' . (string) $this->getParam('field') . ' < DATE_SUB(NOW(), INTERVAL ' . (int) $this->getParam('interval') . ' MONTH)');
-
-        $this->setMessage('Datensätze in der Tabelle ' . $this->getParam('rex_table') . ' gelöscht, die älter als ' . $this->getParam('interval') . ' Monate waren.');
+        
+        // Parameter aus den Einstellungen holen
+        $table = $this->getParam('rex_table');
+        $field = $this->getParam('field');
+        $interval = (int) $this->getParam('interval');
+        
+        // Prüfen, ob die Tabelle existiert
+        $checkTableQuery = 'SHOW TABLES LIKE ' . $sql->escape($table);
+        $sql->setQuery($checkTableQuery);
+        
+        if ($sql->getRows() === 0) {
+            $this->setMessage('Fehler: Tabelle "' . $table . '" existiert nicht.');
+            return false;
+        }
+        
+        // Prüfen, ob das Feld in der Tabelle existiert
+        $checkFieldQuery = sprintf('SHOW COLUMNS FROM `%s` LIKE %s', 
+            $table, // Tabellenname als Identifier (mit Backticks)
+            $sql->escape($field) // Feldname als String (escaped)
+        );
+        $sql->setQuery($checkFieldQuery);
+        
+        if ($sql->getRows() === 0) {
+            $this->setMessage('Fehler: Feld "' . $field . '" existiert nicht in Tabelle "' . $table . '".');
+            return false;
+        }
+        
+        // Sichere DELETE-Query ausführen
+        $deleteQuery = sprintf(
+            'DELETE FROM `%s` WHERE `%s` < DATE_SUB(NOW(), INTERVAL %d MONTH)',
+            $table, // Tabellenname als Identifier
+            $field, // Feldname als Identifier  
+            $interval // Integer ist bereits sicher
+        );
+        
+        $sql->setQuery($deleteQuery);
+        
+        $this->setMessage('Datensätze in der Tabelle ' . $table . ' gelöscht, die älter als ' . $interval . ' Monate waren.');
         return true;
     }
+
 
     public function getTypeName()
     {


### PR DESCRIPTION
Fixes #6 
1. Korrigiert ->query zu ->setQuery
2. Der Vergleich createdate < MONTH(NOW() - INTERVAL 6 MONTH) ist nicht korrekt. Die Funktion MONTH() gibt nur die Monatszahl (1-12) zurück, während createdate wahrscheinlich ein Datum oder Zeitstempel ist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Korrigierte Logik für das Löschen alter Datensätze, sodass jetzt das korrekte Datum für den Vergleich verwendet wird.
  * Verbesserte Validierung und Fehlerbehandlung bei der automatischen Löschung von Tabellendaten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->